### PR TITLE
new changes in the section "Our courses"

### DIFF
--- a/src/css/courses.css
+++ b/src/css/courses.css
@@ -8,11 +8,9 @@
 
 .courses-p {
   font-size: 14px;
-  font-weight: 400;
   color: var(--light-color);
   margin-top: 20px;
   line-height: 1.28;
-  letter-spacing: -0.02em;
 }
 
 .courses-list {
@@ -47,7 +45,7 @@
 }
 
 .courses-icon-svg {
-  stroke: #777777;
+  stroke: var(--icon-color);
   fill: rgba(0, 0, 0, 0);
 }
 


### PR DESCRIPTION
deleted _font-weight: 400;_ (line 11) and _letter-spacing: -0.02em;_ (line 15) because these properties are in the basic settings. Also, the stroke for _.courses-icon-svg_ is written with the variable _var(--icon-color)_